### PR TITLE
Fix timestamp format

### DIFF
--- a/client/templates/chat-detail.ng.html
+++ b/client/templates/chat-detail.ng.html
@@ -13,7 +13,7 @@
               <img ng-src="{{message.picture}}">
             </div>
           </ng-switch>
-          <span class="message-timestamp">{{message.timestamp | amDateFormat: 'HH:MM'}}</span>
+          <span class="message-timestamp">{{message.timestamp | amDateFormat: 'HH:mm'}}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fix timestamp format to use minutes (mm) not months (MM) as per the [momentJS docs](http://momentjs.com/docs/#/displaying/format/).
